### PR TITLE
Include mothur classify.seq option against PR2 database

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -24,7 +24,9 @@ rule all:
         "results/finalData/swarm_table.csv" if config["merge"]["swarm"] and config["general"]["seq_rep"] == "OTU" else [],
         "results/qc/multiqc_report.html" if config["general"]["multiqc"] else [],
         "results/finalData/figures/AmpliconDuo.RData" if config["merge"]["ampliconduo"] and config["merge"]["filter_method"] == "split_sample" else [],
-        "results/finalData/filtered_blast_table.csv" if config["blast"]["blast"] else []
+        "results/finalData/filtered_blast_table.csv" if config["blast"]["blast"] else [],
+        "results/finalData/classify_taxonomy.tsv" if config["classify"]["classify"] else [], 
+        "results/finalData/classify_summary.txt" if config["classify"]["classify"] else [],
        #"results/assembly/A071SE_A/A071SE_A_dada.fasta",
        # "results/assembly/A071SE_B/A071SE_B_dada.fasta",
        # "results/assembly/A172WA_A/A172WA_A_dada.fasta",
@@ -39,3 +41,4 @@ include: "rules/chim_rm.smk"
 include: "rules/merging.smk"
 include: "rules/clustering.smk"
 include: "rules/blast.smk"
+include: "rules/classify.smk"

--- a/envs/classify.yaml
+++ b/envs/classify.yaml
@@ -1,0 +1,9 @@
+name: classify
+channels:
+    - bioconda
+    - conda-forge
+    - defaults
+dependencies:
+    - dinopy=2.2.0
+    - blast=2.9.0
+    - mothur

--- a/example_data.yaml
+++ b/example_data.yaml
@@ -56,3 +56,9 @@ blast:
         ident : 90.0 # Minimal identity overlap between target and query sequence.
         evalue : 1e-51 # Highest accepted evalue.
         out6 : '"6 qseqid qlen length pident mismatch qstart qend sstart send gaps evalue staxid sseqid"' # Additional BLAST information to be saved.
+# classify
+classify:
+        classify: TRUE
+        db_path: database/pr2/pr2.db
+        dnamol: 16S
+        cutoff: 80 # Cutoff of bootstrap value for taxonomic assignment.

--- a/rules/classify.smk
+++ b/rules/classify.smk
@@ -1,0 +1,40 @@
+import os
+
+rule download_pr2:
+	output:
+		os.path.join(os.path.dirname(config["classify"]["db_path"]), "pr2.db.fasta"),
+		os.path.join(os.path.dirname(config["classify"]["db_path"]), "pr2.db.tax")
+	params:
+		db_path=config["classify"]["db_path"],
+		dnamol=config["classify"]["dnamol"]
+	conda:
+		"../envs/classify.yaml"
+	shell:
+		"""
+		dir_name=$(dirname {params[0]});
+		wget -N -P $dir_name/ https://github.com/pr2database/pr2database/releases/download/v4.12.0/pr2_version_4.12.0_{params[1]}_mothur.fasta.gz;
+		wget -N -P $dir_name/ https://github.com/pr2database/pr2database/releases/download/v4.12.0/pr2_version_4.12.0_{params[1]}_mothur.tax.gz;
+		gunzip -c $dir_name/pr2_version_4.12.0_{params[1]}_mothur.fasta.gz > $dir_name/pr2.db.fasta;	
+		gunzip -c $dir_name/pr2_version_4.12.0_{params[1]}_mothur.tax.gz > $dir_name/pr2.db.tax;
+		"""
+		
+rule classify:
+	input:
+		"results/finalData/representatives.fasta" if config["general"]["seq_rep"] == "OTU" else "results/finalData/filtered.fasta", 
+		expand(config["classify"]["db_path"] + "{file_extension}", file_extension=[".fasta", ".tax"])
+	output:
+		"results/finalData/classify_taxonomy.tsv",
+		"results/finalData/classify_summary.txt"
+	threads: 
+		config["general"]["cores"]
+	conda:
+		"../envs/classify.yaml"
+	
+	shell:
+		"""
+		mothur "#classify.seqs(fasta={input[0]}, template={input[1]}, taxonomy = {input[2]}, method=wang)" > mothurlog; #mothur creates another log file
+		mv results/finalData/representatives.db.wang.taxonomy results/finalData/classify_taxonomy.tsv;
+		mv results/finalData/representatives.db.wang.tax.summary results/finalData/classify_summary.txt;
+		mv mothur*logfile results/finalData/;
+		rm mothurlog;
+		"""

--- a/schema/config.schema.yaml
+++ b/schema/config.schema.yaml
@@ -47,6 +47,70 @@ chim:
     default: 1.2
     description: "Pseudo - count prior on number of “no” votes."
     type: float
+classify:
+  classify: 
+    default: false
+    description: "Boolean to indicate the use of the classify.seqs command in mothur to assign taxonomic information to the OTUs."
+    type: boolean
+  db_path:
+    default: database/pr2/pr2.db
+    description: "Path to the database file against which the classify.seqs should be carried out."
+    type: string
+  dnamol:
+    default: 18S
+    description: "Which pr2 database to use, 18S = protists 18S, 16S = protist plastids 16S."
+    oneOf: "18S, 16S"
+    type: string
+  ksize:
+    default: 8
+    description: "Size (length) of k-mer used in the Wang classify method."
+    type: int
+  iters:
+    default: 100
+    description: "How many iterations to do when calculating the bootstrap confidence score for your taxonomy."
+    type: int
+  cutoff:
+    default: 80
+    description: "Cutoff of bootstrap value for taxonomic assignment."
+    type: int
+  probs:
+    default: true
+    description: "Boolean to indicate whether the bootstrap values should be included in the taxonomy output of classify."
+    type: boolean
+  method:
+    default: wang
+    description: "Which method to use with classify.seqs."
+    oneOf: "wang, knn"
+    type: string
+  search:
+    default: kmer
+    description: "Which search algorithm to use with the knn method."
+    oneOf: "kmer, blast, suffix, distance"
+    type: string
+  numwanted:
+    default: 10
+    description: "Number of nearest neighbors (most similar sequences) used to determine the consensus taxonomy with the knn method."
+    type: int
+  gapopen:
+    default: -5
+    description: "Punishment for creating gap, used in blast search method within classify.seqs."
+    type: int
+  gapextend:
+    default: -1
+    description: "Punishment for extending gap, used in blast search method within classify.seqs."
+    type: int
+  relabund: 
+    default: false
+    description: "Boolean to indicate whether the summary files should be relative abundances rather than raw abundances."
+    type: boolean
+  output:
+    default: detail
+    description: "Format of the tax.summary file from classify.seqs"
+    oneOf: "detail, simple"
+  printlevel:
+    default: -1
+    description: "Specify how many taxonomic levels you want printed to your tax.summary file. Default -1 means max level."
+    type: int
 derep:
   clustering:
     default: 1.0


### PR DESCRIPTION
Hi,
I have included an option to use classify.seqs in mothur to classify against the Protist Ribosomal Reference database, which is currently the most well-curated reference database for protists (https://github.com/pr2database/). Which database to use (18S, the most common, or 16S, the ribosomal gene from the chloroplast genome) can be indicated by changing the "dnamol" option.
The classify.seqs command can use several algorithms, currently it is set to the default k-mer search method (Wang), with bootstraps. It can also use k nearest neighbors with blast, but I have not included options for that yet. 
Elianne Egge (member of AG Biodiversität)