### PR TITLE
variable output folder

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,9 +1,10 @@
 import pandas as pd
+import os
 from snakemake.utils import validate
 
 validate(config, "schema/config.schema.yaml")
 
-units = pd.read_table(config["general"]["units"], index_col=["sample", "unit"],
+units = pd.read_table(os.path.join(config["general"]["output_dir"],config["general"]["units"]), index_col=["sample", "unit"],
     dtype=str)
 units.index = units.index.set_levels([i.astype(str) for i in units.index.levels])
 name_ext = config["merge"]["name_ext"][:-1]
@@ -18,13 +19,13 @@ else:
 
 rule all:
     input:
-        "results/finalData/unfiltered_table.csv",
-        "results/finalData/filtered_table.csv",
-        "results/finalData/swarm_table.csv" if config["general"]["seq_rep"] == "OTU" else [],
-        "results/qc/multiqc_report.html" if config["general"]["multiqc"] else [],
-        "results/finalData/figures/AmpliconDuo.RData" if config["merge"]["ampliconduo"] and config["merge"]["filter_method"] == "split_sample" else [],
-        "results/finalData/filtered_blast_table.csv" if config["blast"]["blast"] else [],
-        "results/finalData/filtered_blast_table_complete.csv" if config["blast"]["blast"] else []
+        os.path.join(config["general"]["output_dir"],"results/finalData/unfiltered_table.csv"),
+        os.path.join(config["general"]["output_dir"],"results/finalData/filtered_table.csv"),
+        os.path.join(config["general"]["output_dir"],"results/finalData/swarm_table.csv") if config["general"]["seq_rep"] == "OTU" else [],
+        os.path.join(config["general"]["output_dir"],"results/qc/multiqc_report.html") if config["general"]["multiqc"] else [],
+        os.path.join(config["general"]["output_dir"],"results/finalData/figures/AmpliconDuo.RData") if config["merge"]["ampliconduo"] and config["merge"]["filter_method"] == "split_sample" else [],
+        os.path.join(config["general"]["output_dir"],"results/finalData/filtered_blast_table.csv") if config["blast"]["blast"] else [],
+        os.path.join(config["general"]["output_dir"],"results/finalData/filtered_blast_table_complete.csv") if config["blast"]["blast"] else []
 
 ruleorder: assembly > prinseq
 

--- a/create_dataframe.py
+++ b/create_dataframe.py
@@ -1,7 +1,10 @@
+import pathlib
+
 import yaml
 import pandas as pd
 import numpy as np
 from glob import glob
+import os
 import sys
 
 # Create the datatable containing the samples, units and paths of all
@@ -39,15 +42,17 @@ def create_dataframe(fl, fpl, config, slice):
 
 if __name__ == '__main__':
     if not config['general']['already_assembled']:
-        file_path_list = ['demultiplexed/' + name.split('/')[-1] for name in
+        file_path_list = [os.path.join(config["general"]["output_dir"],'demultiplexed/' + name.split('/')[-1]) for name in
                           sorted(glob(config['general']['filename'] + '/*.gz'))]
         file_list = sorted([file_.split('/')[-1] for file_
                     in file_path_list])
         slice = -3 # Remove the .gz extension from the file paths.
     else:
-        file_path_list = sorted(glob('results/assembly/*/*.fastq'))
+        file_path_list = sorted(glob(os.path.join(config["general"]["output_dir"],'results/assembly/*/*.fastq')))
         file_list = sorted([file_.split('/')[-1] for file_ 
                     in file_path_list])
         slice = None
     df = create_dataframe(file_list, file_path_list, config, slice)
-    df.to_csv('units.tsv', sep='\t')
+
+    pathlib.Path(config["general"]["output_dir"]).mkdir(parents=True, exist_ok=True)
+    df.to_csv(os.path.join(config["general"]["output_dir"],'units.tsv'), sep='\t')

--- a/example_data.yaml
+++ b/example_data.yaml
@@ -1,8 +1,9 @@
 # General options
 general:
         filename : example_data # The path / filename of the project folder, primertable (.csv) and configfile (.yaml). If the raw data folder is not in the root directory of Natrix, please add the path relative to the root directory (e.g. input/example_data)
+        output_dir: output # path to custom output directory / relative to the root directory  of natrix
         primertable: example_data.csv # Path to the primertable. If the primertable is not in the root directory of Natrix, please add the path relative to the root directory (e.g. input/example_data.yaml)
-        units: units.tsv # Path to the sequencing unit sheet.
+        units: units.tsv # Path to the sequencing unit sheet. (name will be concatenated with output_dir)
         cores : 20 # Amount of cores available for the workflow.
         multiqc : FALSE  # Initial quality check (fastqc & multiqc), currently only works for not yet assembled reads.
         demultiplexing: FALSE # Boolean, run demultiplexing for reads if they were not demultiplexed by the sequencing company (slow).

--- a/rules/blast.smk
+++ b/rules/blast.smk
@@ -72,16 +72,16 @@ elif config["blast"]["database"] == "NCBI":
         conda:
             "../envs/blast.yaml"
         log:
-            "results/logs/finalData/BLAST.log"
+            os.path.join(config["general"]["output_dir"],"logs/finalData/BLAST.log")
         script:
             "../scripts/create_blast_taxonomy.py"
 
 rule blast:
     input:
-        "results/finalData/representatives.fasta" if config["general"]["seq_rep"] == "OTU" else "results/finalData/filtered.fasta",
+        os.path.join(config["general"]["output_dir"],"results/finalData/representatives.fasta") if config["general"]["seq_rep"] == "OTU" else os.path.join(config["general"]["output_dir"],"results/finalData/filtered.fasta"),
         expand(config["blast"]["db_path"] + "{file_extension}", file_extension=[".ndb", ".nhr", ".nin", ".nog", ".nos", ".not", ".nsq", ".ntf", ".nto"] if config["blast"]["database"] == "SILVA" else "")
     output:
-        "results/finalData/blast_taxonomy.tsv" #temp
+        os.path.join(config["general"]["output_dir"],"results/finalData/blast_taxonomy.tsv") #temp
     threads: config["general"]["cores"]
     params:
         db_path=config["blast"]["db_path"],
@@ -101,18 +101,18 @@ if config["blast"]["database"] == "NCBI":
 
     rule ncbi_taxonomy:
         input:
-            blast_result = "results/finalData/blast_taxonomy.tsv",
+            blast_result = os.path.join(config["general"]["output_dir"],"results/finalData/blast_taxonomy.tsv"),
             lineage = os.path.join(os.path.dirname(config["blast"]["db_path"]), "tax_lineage.h5")
         output:
-            tax_lineage = temp("results/finalData/blast_taxonomic_lineage.tsv"),
-            all_tax = "results/finalData/blast_taxonomy_all.tsv"
+            tax_lineage = temp(os.path.join(config["general"]["output_dir"],"results/finalData/blast_taxonomic_lineage.tsv")),
+            all_tax = os.path.join(config["general"]["output_dir"],"results/finalData/blast_taxonomy_all.tsv")
         params:
             max_target_seqs=config["blast"]["max_target_seqs"],
             drop_tax_classes=str(config["blast"]["drop_tax_classes"])
         conda:
             "../envs/blast.yaml"
         log:
-            "results/logs/finalData/BLAST.log"
+            os.path.join(config["general"]["output_dir"],"logs/finalData/BLAST.log")
         script:
             "../scripts/ncbi_taxonomy.py"
 
@@ -120,31 +120,31 @@ elif config["blast"]["database"] == "SILVA":
 
     rule silva_taxonomy:
         input:
-            blast_result = "results/finalData/blast_taxonomy.tsv",
+            blast_result = os.path.join(config["general"]["output_dir"],"results/finalData/blast_taxonomy.tsv"),
             lineage = os.path.join(os.path.dirname(config["blast"]["db_path"]), "tax_lineage.h5")
         output:
-            temp("results/finalData/blast_taxonomic_lineage.tsv")
+            temp(os.path.join(config["general"]["output_dir"],"results/finalData/blast_taxonomic_lineage.tsv"))
         params:
             drop_tax_classes=str(config["blast"]["drop_tax_classes"])
         conda:
             "../envs/blast.yaml"
         log:
-            "results/logs/finalData/BLAST.log"
+            os.path.join(config["general"]["output_dir"],"logs/finalData/BLAST.log")
         script:
             "../scripts/silva_taxonomy.py"
 
 rule merge_results:
     input:
-        merged="results/finalData/swarm_table.csv" if config["general"]["seq_rep"] == "OTU" else "results/finalData/filtered_table.csv",
-        blast_result="results/finalData/blast_taxonomic_lineage.tsv"
+        merged=os.path.join(config["general"]["output_dir"],"results/finalData/swarm_table.csv") if config["general"]["seq_rep"] == "OTU" else os.path.join(config["general"]["output_dir"],"results/finalData/filtered_table.csv"),
+        blast_result=os.path.join(config["general"]["output_dir"],"results/finalData/blast_taxonomic_lineage.tsv")
     output:
-        complete="results/finalData/filtered_blast_table_complete.csv",
-        filtered="results/finalData/filtered_blast_table.csv"
+        complete=os.path.join(config["general"]["output_dir"],"results/finalData/filtered_blast_table_complete.csv"),
+        filtered=os.path.join(config["general"]["output_dir"],"results/finalData/filtered_blast_table.csv")
     params:
         seq_rep=str(config["general"]["seq_rep"])
     conda:
         "../envs/merge_results.yaml"
     log:
-        "results/logs/finalData/BLAST.log"
+        os.path.join(config["general"]["output_dir"],"logs/finalData/BLAST.log")
     script:
         "../scripts/merge_results.py"

--- a/rules/chim_rm.smk
+++ b/rules/chim_rm.smk
@@ -1,10 +1,12 @@
+import os
+
 rule vsearch:
     input:
-        "results/assembly/{sample}_{unit}/{sample}_{unit}.dereplicated.fasta" if config["general"]["seq_rep"] == "OTU" else "results/assembly/{sample}_{unit}/{sample}_{unit}_dada.fasta"
+        os.path.join(config["general"]["output_dir"],"results/assembly/{sample}_{unit}/{sample}_{unit}.dereplicated.fasta") if config["general"]["seq_rep"] == "OTU" else os.path.join(config["general"]["output_dir"],"results/assembly/{sample}_{unit}/{sample}_{unit}_dada.fasta")
     output:
-        uchime_out=temp("results/assembly/{sample}_{unit}/{sample}_{unit}.vsearch.txt"),
-        chim="results/assembly/{sample}_{unit}/{sample}_{unit}.chimera.fasta",
-        nonchim="results/finalData/{sample}_{unit}.nonchimera.fasta"
+        uchime_out=temp(os.path.join(config["general"]["output_dir"],"results/assembly/{sample}_{unit}/{sample}_{unit}.vsearch.txt")),
+        chim=os.path.join(config["general"]["output_dir"],"results/assembly/{sample}_{unit}/{sample}_{unit}.chimera.fasta"),
+        nonchim=os.path.join(config["general"]["output_dir"],"results/finalData/{sample}_{unit}.nonchimera.fasta")
     params:
         beta=config["chim"]["beta"],
         pseudo_c=config["chim"]["pseudo_count"],
@@ -13,7 +15,7 @@ rule vsearch:
     conda:
          "../envs/vsearch.yaml"
     log:
-        "results/logs/{sample}_{unit}/vsearch.log"
+        os.path.join(config["general"]["output_dir"],"logs/{sample}_{unit}/vsearch.log")
     shell:
         "vsearch --uchime3_denovo {input} -uchimeout {output.uchime_out}"
         " -chimeras {output.chim} -nonchimeras {output.nonchim} -xn {params.beta}"

--- a/rules/clustering.smk
+++ b/rules/clustering.smk
@@ -1,12 +1,13 @@
+import os
 # dada runs per sample after preprocessing and before chimera removal and AmpliconDuo
 rule DADA2:
     input:
         fwd = expand(
-            "results/assembly/{unit.sample}_{unit.unit}/{unit.sample}_{unit.unit}_1_cut.fastq", unit=units.reset_index().itertuples()),
+            os.path.join(config["general"]["output_dir"],"results/assembly/{unit.sample}_{unit.unit}/{unit.sample}_{unit.unit}_1_cut.fastq"), unit=units.reset_index().itertuples()),
         rev = expand(
-            "results/assembly/{unit.sample}_{unit.unit}/{unit.sample}_{unit.unit}_2_cut.fastq", unit=units.reset_index().itertuples()) if config["merge"]["paired_End"] == True else []
+            os.path.join(config["general"]["output_dir"],"results/assembly/{unit.sample}_{unit.unit}/{unit.sample}_{unit.unit}_2_cut.fastq"), unit=units.reset_index().itertuples()) if config["merge"]["paired_End"] == True else []
     output:
-        expand("results/assembly/{unit.sample}_{unit.unit}/{unit.sample}_{unit.unit}_dada.fasta", unit=units.reset_index().itertuples())
+        expand(os.path.join(config["general"]["output_dir"],"results/assembly/{unit.sample}_{unit.unit}/{unit.sample}_{unit.unit}_dada.fasta"), unit=units.reset_index().itertuples())
     params:
         paired_end=config["merge"]["paired_End"],
         minoverlap=config["qc"]["minoverlap"],
@@ -14,17 +15,17 @@ rule DADA2:
     conda:
         "../envs/dada2.yaml"
     log:
-        "results/logs/dada2.log"
+        os.path.join(config["general"]["output_dir"],"logs/dada2.log")
     script:
         "../scripts/dada2.R"
 
 # SWARM clustering runs on all samples after AmpliconDuo
 rule write_fasta:
     input:
-        "results/finalData/filtered_table_temp.csv"
+        os.path.join(config["general"]["output_dir"],"results/finalData/filtered_table_temp.csv")
     output:
-        "results/finalData/filtered.fasta",
-        "results/finalData/filtered_table.csv"
+        os.path.join(config["general"]["output_dir"],"results/finalData/filtered.fasta"),
+        os.path.join(config["general"]["output_dir"],"results/finalData/filtered_table.csv")
     run:
         import csv
         with open(input[0], "r") as csv_in, open(
@@ -43,10 +44,10 @@ rule write_fasta:
 
 rule swarm:
     input:
-        "results/finalData/filtered.fasta"
+        os.path.join(config["general"]["output_dir"],"results/finalData/filtered.fasta")
     output:
-        "results/finalData/representatives.fasta",
-        temp("results/finalData/merged.swarms")
+        os.path.join(config["general"]["output_dir"],"results/finalData/representatives.fasta"),
+        temp(os.path.join(config["general"]["output_dir"],"results/finalData/merged.swarms"))
     threads: config["general"]["cores"]
     conda:
         "../envs/swarm.yaml"
@@ -55,10 +56,10 @@ rule swarm:
 
 rule swarm_results:
     input:
-        merged="results/finalData/merged.swarms",
-        final_table_path2="results/finalData/filtered_table.csv"
+        merged=os.path.join(config["general"]["output_dir"],"results/finalData/merged.swarms"),
+        final_table_path2=os.path.join(config["general"]["output_dir"],"results/finalData/filtered_table.csv")
     output:
-        "results/finalData/swarm_table.csv"
+        os.path.join(config["general"]["output_dir"],"results/finalData/swarm_table.csv")
     conda:
         "../envs/merge_results.yaml"
     script:

--- a/rules/demultiplexing.smk
+++ b/rules/demultiplexing.smk
@@ -1,13 +1,16 @@
+import os
+
 rule demultiplex:
     output:
-        temp(expand("demultiplexed/{unit.sample}_{unit.unit}_R{read}.fastq.gz", unit=units.reset_index().itertuples(), read=reads))
+        temp(expand(os.path.join(config["general"]["output_dir"],"demultiplexed/{unit.sample}_{unit.unit}_R{read}.fastq.gz"), unit=units.reset_index().itertuples(), read=reads))
     params:
         filename = config["general"]["filename"],
         primertable = config["general"]["primertable"],
         demultiplexing = config["general"]["demultiplexing"],
         read_sorting = config['general']['read_sorting'],
         assembled = config['general']['already_assembled'],
-        name_ext = config['merge']['name_ext']
+        name_ext = config['merge']['name_ext'],
+        output_dir = config['general']['output_dir']
     conda:
         "../envs/demultiplexing.yaml"
     script:
@@ -15,8 +18,8 @@ rule demultiplex:
 
 rule unzip:
     input:
-         "demultiplexed/{sample}_{unit}_R{read}.fastq.gz"
+         os.path.join(config["general"]["output_dir"],"demultiplexed/{sample}_{unit}_R{read}.fastq.gz")
     output:
-        temp("demultiplexed/{sample}_{unit}_{read}.fastq")
+        temp(os.path.join(config["general"]["output_dir"],"demultiplexed/{sample}_{unit}_{read}.fastq"))
     shell:
          "gunzip -c {input} > {output}"

--- a/rules/dereplication.smk
+++ b/rules/dereplication.smk
@@ -1,9 +1,11 @@
+import os
+
 rule cdhit:
     input:
-        "results/assembly/{sample}_{unit}/{sample}_{unit}.fasta"
+        os.path.join(config["general"]["output_dir"],"results/assembly/{sample}_{unit}/{sample}_{unit}.fasta")
     output:
-        "results/assembly/{sample}_{unit}/{sample}_{unit}_cdhit.fasta",
-        temp("results/assembly/{sample}_{unit}/{sample}_{unit}_cdhit.fasta.clstr")
+        os.path.join(config["general"]["output_dir"],"results/assembly/{sample}_{unit}/{sample}_{unit}_cdhit.fasta"),
+        temp(os.path.join(config["general"]["output_dir"],"results/assembly/{sample}_{unit}/{sample}_{unit}_cdhit.fasta.clstr"))
     conda:
         "../envs/dereplication.yaml"
     threads: config["general"]["cores"]
@@ -16,11 +18,11 @@ rule cdhit:
 
 rule cluster_sorting:
     input:
-        "results/assembly/{sample}_{unit}/{sample}_{unit}_cdhit.fasta",
-        "results/assembly/{sample}_{unit}/{sample}_{unit}_cdhit.fasta.clstr",
-        "results/assembly/{sample}_{unit}/{sample}_{unit}.fasta"
+        os.path.join(config["general"]["output_dir"],"results/assembly/{sample}_{unit}/{sample}_{unit}_cdhit.fasta"),
+        os.path.join(config["general"]["output_dir"],"results/assembly/{sample}_{unit}/{sample}_{unit}_cdhit.fasta.clstr"),
+        os.path.join(config["general"]["output_dir"],"results/assembly/{sample}_{unit}/{sample}_{unit}.fasta")
     output:
-        "results/assembly/{sample}_{unit}/{sample}_{unit}.dereplicated.fasta"
+        os.path.join(config["general"]["output_dir"],"results/assembly/{sample}_{unit}/{sample}_{unit}.dereplicated.fasta")
     conda:
         "../envs/dereplication.yaml"
     params:

--- a/rules/merging.smk
+++ b/rules/merging.smk
@@ -1,9 +1,11 @@
+import os
+
 rule unfiltered_table:
     input:
-        expand("results/finalData/{unit.sample}_{unit.unit}.nonchimera.fasta", unit=units.reset_index().itertuples())
+        expand(os.path.join(config["general"]["output_dir"],"results/finalData/{unit.sample}_{unit.unit}.nonchimera.fasta"), unit=units.reset_index().itertuples())
     output:
-        "results/finalData/unfiltered_table.csv",
-        temp("results/finalData/unfiltered_dict.hdf5")
+        os.path.join(config["general"]["output_dir"],"results/finalData/unfiltered_table.csv"),
+        temp(os.path.join(config["general"]["output_dir"],"results/finalData/unfiltered_dict.hdf5"))
     conda:
         "../envs/unfiltered_table.yaml"
     script:
@@ -11,10 +13,10 @@ rule unfiltered_table:
 
 rule filtering:
     input:
-        "results/finalData/unfiltered_dict.hdf5"
+        os.path.join(config["general"]["output_dir"],"results/finalData/unfiltered_dict.hdf5")
     output:
-          temp("results/finalData/filtered_table_temp.csv"),
-          "results/finalData/filtered_out_table.csv"
+          temp(os.path.join(config["general"]["output_dir"],"results/finalData/filtered_table_temp.csv")),
+          os.path.join(config["general"]["output_dir"],"results/finalData/filtered_out_table.csv")
     params:
         filter_method=config["merge"]["filter_method"],
         cutoff=config["merge"]["cutoff"]
@@ -25,10 +27,10 @@ rule filtering:
 
 rule ampliconduo:
     input:
-        filtered_table="results/finalData/filtered_table_temp.csv",
-        unfiltered_table="results/finalData/unfiltered_table.csv"
+        filtered_table=os.path.join(config["general"]["output_dir"],"results/finalData/filtered_table_temp.csv"),
+        unfiltered_table=os.path.join(config["general"]["output_dir"],"results/finalData/unfiltered_table.csv")
     output:
-        "results/finalData/figures/AmpliconDuo.RData"
+        os.path.join(config["general"]["output_dir"],"results/finalData/figures/AmpliconDuo.RData")
     params:
         plot_ampduo=config["merge"]["plot_AmpDuo"],
         saving_format=config["merge"]["save_format"],
@@ -36,6 +38,6 @@ rule ampliconduo:
     conda:
         "../envs/ampliconduo.yaml"
     log:
-        "results/logs/ampliconduo.log"
+        os.path.join(config["general"]["output_dir"],"logs/ampliconduo.log")
     script:
         "../scripts/ampliconduo.R"

--- a/rules/quality_control.smk
+++ b/rules/quality_control.smk
@@ -1,9 +1,11 @@
+import os
+
 rule fastqc:
     input:
-        "demultiplexed/{sample}_{unit}_R{read}.fastq.gz"
+        os.path.join(config["general"]["output_dir"],"demultiplexed/{sample}_{unit}_R{read}.fastq.gz")
     output:
-        "results/qc/{sample}_{unit}_R{read}_fastqc.html",
-        "results/qc/{sample}_{unit}_R{read}_fastqc.zip"
+        os.path.join(config["general"]["output_dir"],"results/qc/{sample}_{unit}_R{read}_fastqc.html"),
+        os.path.join(config["general"]["output_dir"],"results/qc/{sample}_{unit}_R{read}_fastqc.zip")
     threads: 20
     conda:
         "../envs/quality_control.yaml"
@@ -12,11 +14,13 @@ rule fastqc:
 
 rule multiqc:
     input:
-        expand("results/qc/{unit.sample}_{unit.unit}_R{read}_fastqc.zip",
+        expand(os.path.join(config["general"]["output_dir"],"results/qc/{unit.sample}_{unit.unit}_R{read}_fastqc.zip"),
         unit=units.reset_index().itertuples(), read=reads)
     output:
-        "results/qc/multiqc_report.html"
+        os.path.join(config["general"]["output_dir"],"results/qc/multiqc_report.html")
+    params:
+        config["general"]["output_dir"]
     conda:
         "../envs/quality_control.yaml"
     shell:
-        "multiqc results/qc/ -o results/qc/"
+        "multiqc {params}/results/qc/ -o {params}/results/qc/"

--- a/rules/read_assembly.smk
+++ b/rules/read_assembly.smk
@@ -1,14 +1,16 @@
+import os
+
 def get_fastq(wildcards):
     if not is_single_end(wildcards.sample, wildcards.unit):
-        return expand("demultiplexed/{sample}_{unit}_{group}.fastq",
+        return expand(os.path.join(config["general"]["output_dir"],"demultiplexed/{sample}_{unit}_{group}.fastq"),
                         group=[1,2], **wildcards)
-    return "demultiplexed/{sample}_{unit}_1.fastq".format(**wildcards)
+    return os.path.join(config["general"]["output_dir"],"demultiplexed/{sample}_{unit}_1.fastq").format(**wildcards)
 
 rule define_primer:
     input:
         primer_table=config["general"]["primertable"]
     output:
-        "primer_table.csv"
+        os.path.join(config["general"]["output_dir"],"primer_table.csv")
     params:
        paired_end=config["merge"]["paired_End"],
        offset=config["qc"]["primer_offset"],
@@ -24,12 +26,12 @@ rule prinseq:
         sample=get_fastq
     output:
         expand(
-        "results/assembly/{{sample}}_{{unit}}/{{sample}}_{{unit}}_{read}.fastq",
+        os.path.join(config["general"]["output_dir"],"results/assembly/{{sample}}_{{unit}}/{{sample}}_{{unit}}_{read}.fastq"),
         read=reads)
     params:
         config["qc"]["mq"]
     log:
-        "results/logs/{sample}_{unit}/prinseq.log"
+        os.path.join(config["general"]["output_dir"],"logs/{sample}_{unit}/prinseq.log")
     conda:
         "../envs/prinseq.yaml"
     script:
@@ -38,12 +40,12 @@ rule prinseq:
 rule cutadapt:
     input:
         expand(
-        "results/assembly/{{sample}}_{{unit}}/{{sample}}_{{unit}}_{read}.fastq",
+        os.path.join(config["general"]["output_dir"],"results/assembly/{{sample}}_{{unit}}/{{sample}}_{{unit}}_{read}.fastq"),
         read=reads),
-        primer_t="primer_table.csv"
+        primer_t=os.path.join(config["general"]["output_dir"],"primer_table.csv")
     output:
         expand(
-        "results/assembly/{{sample}}_{{unit}}/{{sample}}_{{unit}}_{read}_cut.fastq",
+        os.path.join(config["general"]["output_dir"],"results/assembly/{{sample}}_{{unit}}/{{sample}}_{{unit}}_{read}_cut.fastq"),
         read=reads)
     params:
         paired_end=config["merge"]["paired_End"],
@@ -54,18 +56,18 @@ rule cutadapt:
     conda:
         "../envs/cutadapt.yaml"
     log:
-        "results/logs/{sample}_{unit}/cutadapt.log"
+        os.path.join(config["general"]["output_dir"],"logs/{sample}_{unit}/cutadapt.log")
     script:
         "../scripts/cutadapt.py"
 
 rule assembly:
     input:
         expand(
-        "results/assembly/{{sample}}_{{unit}}/{{sample}}_{{unit}}_{read}.fastq",
+        os.path.join(config["general"]["output_dir"],"results/assembly/{{sample}}_{{unit}}/{{sample}}_{{unit}}_{read}.fastq"),
         read=reads),
-        primer_t="primer_table.csv"
+        primer_t=os.path.join(config["general"]["output_dir"],"primer_table.csv")
     output:
-        "results/assembly/{sample}_{unit}/{sample}_{unit}_assembled.fastq"
+        os.path.join(config["general"]["output_dir"],"results/assembly/{sample}_{unit}/{sample}_{unit}_assembled.fastq")
     threads: 20
     params:
         paired_end=config["merge"]["paired_End"],
@@ -78,15 +80,15 @@ rule assembly:
     conda:
         "../envs/assembly.yaml"
     log:
-        "results/logs/{sample}_{unit}/read_assembly.log"
+        os.path.join(config["general"]["output_dir"],"logs/{sample}_{unit}/read_assembly.log")
     script:
         "../scripts/assembly.py"
 
 rule copy_to_fasta:
     input:
-        "results/assembly/{sample}_{unit}/{sample}_{unit}_assembled.fastq"
+        os.path.join(config["general"]["output_dir"],"results/assembly/{sample}_{unit}/{sample}_{unit}_assembled.fastq")
     output:
-        "results/assembly/{sample}_{unit}/{sample}_{unit}.fasta"
+        os.path.join(config["general"]["output_dir"],"results/assembly/{sample}_{unit}/{sample}_{unit}.fasta")
     conda:
         "../envs/seqtk.yaml"
     shell:

--- a/schema/config.schema.yaml
+++ b/schema/config.schema.yaml
@@ -101,6 +101,10 @@ general:
     description: "How the sequences should be represented, possible values are: 'ASV', amplicon sequence variants, created with DADA2 or 'OTU', operational taxonomic units, created with SWARM"
     oneOf: "OTU, ASV"
     type: string
+  output_dir:
+    default: output
+    description: "path to custom output directory / relative to the root directory  of natrix"
+    type: string
 merge:
   ampli_corr:
     default: fdr

--- a/scripts/demultiplexing.py
+++ b/scripts/demultiplexing.py
@@ -85,8 +85,8 @@ def demultiplexer(file_path_list):
     for sample in primertable.keys():
         samples.append(sample + '_R1')
         samples.append(sample + '_R2')
-        output_filepaths.append('demultiplexed/' + sample + '_R1.fastq.gz')
-        output_filepaths.append('demultiplexed/' + sample + '_R2.fastq.gz')
+        output_filepaths.append(snakemake.params.output_dir+'/demultiplexed/' + sample + '_R1.fastq.gz')
+        output_filepaths.append(snakemake.params.output_dir+'/demultiplexed/' + sample + '_R2.fastq.gz')
 
     # Create a dict of writers.
     writers = {name: dinopy.FastqWriter(path) for name, path in
@@ -115,17 +115,17 @@ def demultiplexer(file_path_list):
         writer.close()
 
 def read_sorter(primertable):
-    if not os.path.exists('demultiplexed/not_sorted'):
-        os.mkdir('demultiplexed/not_sorted')
+    if not os.path.exists(snakemake.params.output_dir+'/demultiplexed/not_sorted'):
+        os.mkdir(snakemake.params.output_dir+'/demultiplexed/not_sorted')
     samples = []
     output_filepaths = []
     for sample in primertable.keys():
         samples.append(sample + snakemake.params.name_ext[:-1] + '1')
         samples.append(sample + snakemake.params.name_ext[:-1] + '2')
         samples.append(sample + '_not_sorted')
-        output_filepaths.append('demultiplexed/' + sample + '_R1.fastq.gz')
-        output_filepaths.append('demultiplexed/' + sample + '_R2.fastq.gz')
-        output_filepaths.append('demultiplexed/not_sorted/' + sample + '_not_sorted.fastq.gz')
+        output_filepaths.append(snakemake.params.output_dir+'/demultiplexed/' + sample + '_R1.fastq.gz')
+        output_filepaths.append(snakemake.params.output_dir+'/demultiplexed/' + sample + '_R2.fastq.gz')
+        output_filepaths.append(snakemake.params.output_dir+'/demultiplexed/not_sorted/' + sample + '_not_sorted.fastq.gz')
 
     # Create a dict of writers.
     writers = {name: dinopy.FastqWriter(path) for name, path in
@@ -171,10 +171,10 @@ def already_assembled(primertable, file_path_list):
             subprocess.run(['gunzip', f_])
             f_ = f_.split('.gz')[0]
         for sample in primertable.keys():
-            pathlib.Path('../results/assembly/' + sample).mkdir(parents=True, exist_ok=True)
+            pathlib.Path(snakemake.params.output_dir+'/results/assembly/' + sample).mkdir(parents=True, exist_ok=True)
             if sample in f_:
-                shutil.copy(f_, '../results/assembly/' + sample + '/' + sample + '_assembled.fastq')
-                shutil.copy(f_, '../demultiplexed/')
+                shutil.copy(f_, snakemake.params.output_dir+'/results/assembly/' + sample + '/' + sample + '_assembled.fastq')
+                shutil.copy(f_, snakemake.params.output_dir+'/demultiplexed/')
 
 
 # Run the demultiplexing / read sorting script.
@@ -193,4 +193,4 @@ else:
     # the demultiplexed folder. Leave original files in input folder
     for file in file_path_list:
         print(file)
-        shutil.copy(file, 'demultiplexed/')
+        shutil.copy(file, os.path.join(snakemake.params.output_dir,'demultiplexed/'))


### PR DESCRIPTION
added config value to specify an output dir. The default is "output" in the working dir of Natrix. 
All* Files (demultiplexing,results,logs,units.tsv&primer_table will be created inside that folder)

I have *not* tested this with the docker environment, and some of the other pull requests might introduce merge conflicts.

*ampliconduo produces a wild Rplots.pdf in the working dir of Natrix.